### PR TITLE
Add opcua-gateway-version and opcua-coordinator-version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
     },
     "./features/opcua-connector": {
       "useLocalSdk": true,
-      "opcua-connector-version": "latest"
+      "opcua-coordinator-version": "latest",
+      "opcua-gateway-version": "latest"
     }
   },
   "containerEnv": {

--- a/.devcontainer/features/opcua-connector/README.md
+++ b/.devcontainer/features/opcua-connector/README.md
@@ -63,12 +63,13 @@ Example configuration:
 
 ## ⚙️ Optional Settings
 
-| Option ID                 | Description                                                 | Type    | Default Value               |
-| ------------------------- | ----------------------------------------------------------- | ------- | --------------------------- |
-| `opcua-connector-version` | Git ref of the OPC UA Connector image to install            | string  | *(matches feature version)* |
-| `useLocalSdk`             | Use local SDK source code instead of installing from GitHub | boolean | `false`                     |
+| Option ID                   | Description                                                 | Type    | Default Value               |
+| --------------------------- | ----------------------------------------------------------- | ------- | --------------------------- |
+| `opcua-coordinator-version` | Git ref of the OPC UA Coordinator image to install          | string  | *(matches feature version)* |
+| `opcua-gateway-version`     | Git ref of the OPC UA Gateway image to install              | string  | *(matches feature version)* |
+| `useLocalSdk`               | Use local SDK source code instead of installing from GitHub | boolean | `false`                     |
 
-> 📝 **Note:** The default `opcua-connector-version` matches the OpenFactory Core version this feature was developed and tested against. Most users do not need to override it.
+> 📝 **Note:** The default `opcua-coordinator-version` and `opcua-gateway-version` matche the OpenFactory Core version this feature was developed and tested against. Most users do not need to override it.
 
 ---
 

--- a/.devcontainer/features/opcua-connector/assets/docker-compose.yml
+++ b/.devcontainer/features/opcua-connector/assets/docker-compose.yml
@@ -26,7 +26,7 @@
 
 services:
   opcua-gateway:
-    image: ghcr.io/openfactoryio/opcua-gateway:${OPCUA_CONNECTOR_VERSION}
+    image: ghcr.io/openfactoryio/opcua-gateway:${OPCUA_GATEWAY_VERSION}
     container_name: opcua-gateway
     environment:
       - GATEWAY_HOST=opcua-gateway
@@ -38,7 +38,7 @@ services:
       - "${GATEWAY_PORT:-8001}:8001"
 
   opcua-coordinator:
-    image: ghcr.io/openfactoryio/opcua-coordinator:${OPCUA_CONNECTOR_VERSION}
+    image: ghcr.io/openfactoryio/opcua-coordinator:${OPCUA_COORDINATOR_VERSION}
     container_name: opcua-coordinator
     environment:
       - KAFKA_BROKER=${KAFKA_BROKER}

--- a/.devcontainer/features/opcua-connector/devcontainer-feature.json
+++ b/.devcontainer/features/opcua-connector/devcontainer-feature.json
@@ -4,10 +4,15 @@
   "name": "OpenFactory OPC UA Connector",
   "description": "Installs the OpenFactory OPC UA Connector",
   "options": {
-    "opcua-connector-version": {
+    "opcua-gateway-version": {
       "type": "string",
       "default": "v0.4.4",
-      "description": "Git ref of the OPC UA Connector image to install"
+      "description": "Git ref of the OPC UA Gateway image to install"
+    },
+    "opcua-coordinator-version": {
+      "type": "string",
+      "default": "v0.4.4",
+      "description": "Git ref of the OPC UA Coordinator image to install"
     },
     "useLocalSdk": {
       "type": "boolean",

--- a/.devcontainer/features/opcua-connector/install.sh
+++ b/.devcontainer/features/opcua-connector/install.sh
@@ -11,7 +11,8 @@ cp -r "$(dirname "$0")/assets/." "/usr/local/share/openfactory-opcua"
 echo "🛠️ Setting environment variables..."
 
 # Capture version from feature options (install-time)
-echo "export OPCUA_CONNECTOR_VERSION=\"${OPCUA_CONNECTOR_VERSION}\"" > /etc/profile.d/00-openfactory-opcua.sh
+echo "export OPCUA_GATEWAY_VERSION=\"${OPCUA_GATEWAY_VERSION}\"" > /etc/profile.d/00-openfactory-opcua.sh
+echo "export OPCUA_COORDINATOR_VERSION=\"${OPCUA_COORDINATOR_VERSION}\"" >> /etc/profile.d/00-openfactory-opcua.sh
 
 # Append runtime-dependent variables
 cat << 'EOF' >> /etc/profile.d/00-openfactory-opcua.sh

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -167,29 +167,35 @@ def bump_opcua_feature_version(version: str) -> None:
         data = json.load(f)
 
     if "version" not in data or "options" not in data \
-       or "opcua-connector-version" not in data["options"] \
-       or "default" not in data["options"]["opcua-connector-version"]:
-        print("ERROR: Required fields missing in opcua-connector devcontainer-feature.json.")
+       or "opcua-gateway-version" not in data["options"] \
+       or "opcua-coordinator-version" not in data["options"] \
+       or "default" not in data["options"]["opcua-gateway-version"] \
+       or "default" not in data["options"]["opcua-coordinator-version"]:
+        print("ERROR: Required fields missing in devcontainer-feature.json.")
         sys.exit(1)
 
     old_version = data["version"]
-    old_default = data["options"]["opcua-connector-version"]["default"]
+    old_default_gateway = data["options"]["opcua-gateway-version"]["default"]
+    old_default_coordinator = data["options"]["opcua-coordinator-version"]["default"]
 
     if version == "dev":
         base_version = old_version.split("-")[0]
         new_version = f"{base_version}-dev.1"
         data["version"] = new_version
-        data["options"]["opcua-connector-version"]["default"] = "main"
+        data["options"]["opcua-gateway-version"]["default"] = "main"
+        data["options"]["opcua-coordinator-version"]["default"] = "main"
     else:
         data["version"] = version
-        data["options"]["opcua-connector-version"]["default"] = f"v{version}"
+        data["options"]["opcua-gateway-version"]["default"] = f"v{version}"
+        data["options"]["opcua-coordinator-version"]["default"] = f"v{version}"
 
     with json_path.open("w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
         f.write("\n")
 
     print(f"[opcua-connector] version updated: {old_version} → {data['version']}")
-    print(f"[opcua-connector] opcua-connector-version.default updated: {old_default} → {data['options']['opcua-connector-version']['default']}")
+    print(f"[opcua-gateway] opcua-gateway-version.default updated: {old_default_gateway} → {data['options']['opcua-gateway-version']['default']}")
+    print(f"[opcua-coordinator] opcua-coordinator-version.default updated: {old_default_coordinator} → {data['options']['opcua-coordinator-version']['default']}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add `opcua-coordinator-version` and `opcua-gateway-version` as new feature options to the OpenFactory OPC UA Connector feature. This will replace the old option `opcua-connector-version`.

This is needed as OpenFactory core developers will need to be able to select specific versions of the OPC UA Coordiantor and Gateway.