### PR TITLE
77 add openfactory mocked nfs server dev container feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,8 @@
       "useLocalSdk": true,
       "opcua-coordinator-version": "latest",
       "opcua-gateway-version": "latest"
-    }
+    },
+    "./features/nfs-server": {}
   },
   "containerEnv": {
     "ENVIRONMENT": "local",
@@ -36,7 +37,13 @@
   "customizations": {
     "vscode": {
       "settings": {
-        "terminal.integrated.shell.linux": "/bin/bash"
+        "terminal.integrated.defaultProfile.linux": "bash-login",
+        "terminal.integrated.profiles.linux": {
+          "bash-login": {
+            "path": "/bin/bash",
+            "args": ["-l"]
+          }
+        }
       },
       "extensions": [
         "ms-python.python",

--- a/.devcontainer/features/nfs-server/README.md
+++ b/.devcontainer/features/nfs-server/README.md
@@ -1,0 +1,215 @@
+# OpenFactory NFS Server Dev Container Feature
+
+Installs a mocked NFS server utility inside your Dev Container for use with the OpenFactory SDK.
+
+## 🐳 Deploy OpenFactory Mocked NFS Server
+
+Once installed, the feature allows you to start a mocked NFS server suitable for testing OpenFactory applications requiring shared NFS storage.
+
+Start the mocked NFS server:
+
+```bash
+nfs-start
+```
+
+Stop and remove the mocked NFS server:
+
+```bash
+nfs-stop
+```
+
+The NFS server is deployed as a Docker container inside your development environment.
+
+---
+
+## 🚀 Usage
+
+This section describes how to configure the feature in your devcontainer depending on your use case.
+
+> ⚠️ **Prerequisite:** This feature requires Docker support inside the Dev Container.
+> Use the `docker-in-docker` Dev Container feature.
+
+### 1️⃣ OpenFactory Application Developers
+
+Application developers building OpenFactory applications should **pin the SDK feature version** to match the OpenFactory version running in their factory.
+
+Example configuration:
+
+```json
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/openfactoryio/openfactory-sdk/nfs-server:0.5.4": {}
+  }
+}
+```
+
+> 💡 **Tip:** Version pinning ensures compatibility with the OpenFactory Core version running in your factory.
+
+### 2️⃣ OpenFactory Core Developers
+
+Core developers contributing to OpenFactory usually want the **latest development version** of the SDK feature.
+
+Example configuration:
+
+```json
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/openfactoryio/openfactory-sdk/nfs-server:0.0.0-dev.05580d9": {}
+  }
+}
+```
+
+> 📝 **Note:** The latest development version of the SDK feature can be found at [OpenFactory SDK Container Registry](https://github.com/openfactoryio/openfactory-sdk/pkgs/container/openfactory-sdk%2Fnfs-server?utm_source=chatgpt.com)
+
+---
+
+## ⚙️ Optional Settings
+
+| Option ID        | Description                                                 | Type    | Default Value    |
+| ---------------- | ----------------------------------------------------------- | ------- | ---------------- |
+| `nfs-mountpoint` | Path exported by the mocked NFS server                      | string  | `/ofa/nfsvolume` |
+| `nfs-uid`        | UID owning the exported NFS mountpoint                      | string  | `1200`           |
+| `nfs-gid`        | GID owning the exported NFS mountpoint                      | string  | `1200`           |
+
+Example configuration:
+
+```json
+{
+  "features": {
+    "ghcr.io/openfactoryio/openfactory-sdk/nfs-server:0.5.5": {
+      "nfs-mountpoint": "/shared/data",
+      "nfs-uid": "2100",
+      "nfs-gid": "2200"
+    }
+  }
+}
+```
+This creates an NFS export:
+```
+/shared/data
+```
+owned by:
+```
+UID=2100
+GID=2200
+```
+Applications accessing the NFS export should typically run with the same UID/GID.
+
+---
+
+## ✅ What This Feature Does
+
+* Copies the mocked NFS server utility scripts into:
+
+  ```bash
+  /usr/local/share/openfactory-nfs
+  ```
+
+* Defines the following environment variables:
+
+  ```bash
+  NFS_CONTAINER_NAME=devcontainer-nfs
+  NFS_VOLUME_NAME=devcontainer-nfsdata
+  NFS_NETWORK_NAME=factory-net
+
+  NFS_MOUNTPOINT=<nfs-mountpoint>
+  NFS_UID=<nfs-uid>
+  NFS_GID=<nfs-gid>
+  ```
+
+* Adds these shell aliases:
+
+  ```bash
+  nfs-start   # Start the mocked NFS server
+  nfs-stop    # Stop and remove the mocked NFS server
+  ```
+
+* Creates a mocked NFS server container using:
+
+  ```bash
+  itsthenetwork/nfs-server-alpine
+  ```
+
+* Creates a persistent Docker volume for NFS storage:
+
+  ```bash
+  devcontainer-nfsdata
+  ```
+
+---
+
+## 📦 Mounting the NFS Export
+
+After starting the mocked NFS server:
+
+```bash
+nfs-start
+```
+
+the utility displays:
+
+* the NFS server IP
+* the exported mountpoint
+* the UID/GID owning the export
+
+You can mount the export from another container or from the Dev Container itself using:
+
+```bash
+sudo mount -t nfs <NFS_SERVER_IP>:<NFS_MOUNTPOINT> /your/local/mountpoint
+```
+
+Example:
+
+```bash
+sudo mount -t nfs 172.18.0.5:/ofa/nfsvolume /mnt/nfs
+```
+
+> ⚠️ Applications accessing the NFS export should typically run with the same UID/GID configured for the export.
+
+---
+
+## 🧪 For Feature Developers
+
+If you're contributing to this feature, you may want to install it from the local source during development.
+
+Example `.devcontainer/devcontainer.json`:
+
+```json
+{
+  "features": {
+    "./features/nfs-server": {}
+  }
+}
+```
+
+When developing locally, you may also want Bash terminals to automatically source `/etc/profile.d` scripts:
+
+```json
+{
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash-login",
+        "terminal.integrated.profiles.linux": {
+          "bash-login": {
+            "path": "/bin/bash",
+            "args": ["-l"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+This ensures feature environment variables such as:
+
+```bash
+$NFS_UID
+$NFS_GID
+$NFS_MOUNTPOINT
+```
+
+are immediately available in newly opened VS Code terminals.

--- a/.devcontainer/features/nfs-server/assets/start-nfs.sh
+++ b/.devcontainer/features/nfs-server/assets/start-nfs.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# OpenFactory Mocked NFS Server
+#
+# Starts (or reuses) a mocked NFS server container suitable for the
+# OpenFactory SDK.
+#
+# Required environment variables:
+#
+#   NFS_UID
+#   NFS_GID
+#   NFS_MOUNTPOINT
+#
+# -----------------------------------------------------------------------------
+
+NFS_CONTAINER_NAME="devcontainer-nfs"
+NFS_VOLUME_NAME="devcontainer-nfsdata"
+NFS_NETWORK_NAME="factory-net"
+
+echo "⚙️  Starting OpenFactory mocked NFS server..."
+echo "    NFS mountpoint : ${NFS_MOUNTPOINT}"
+echo "    NFS UID:GID    : ${NFS_UID}:${NFS_GID}"
+
+# -----------------------------------------------------------------------------
+# Validate environment
+# -----------------------------------------------------------------------------
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "❌ Docker is required but was not found."
+    exit 1
+fi
+
+if [ -z "${NFS_UID:-}" ]; then
+    echo "❌ NFS_UID is not set."
+    exit 1
+fi
+
+if [ -z "${NFS_GID:-}" ]; then
+    echo "❌ NFS_GID is not set."
+    exit 1
+fi
+
+if [ -z "${NFS_MOUNTPOINT:-}" ]; then
+    echo "❌ NFS_MOUNTPOINT is not set."
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Create network if needed
+# -----------------------------------------------------------------------------
+
+echo "🔍 Checking Docker network '${NFS_NETWORK_NAME}'..."
+
+if ! docker network inspect "${NFS_NETWORK_NAME}" >/dev/null 2>&1; then
+    echo "🔗 Creating Docker network '${NFS_NETWORK_NAME}'..."
+
+    docker network create \
+        --driver bridge \
+        --label com.docker.compose.network="${NFS_NETWORK_NAME}" \
+        "${NFS_NETWORK_NAME}"
+else
+    echo "✅ Network already exists."
+fi
+
+# -----------------------------------------------------------------------------
+# Create persistent volume if needed
+# -----------------------------------------------------------------------------
+
+echo "🔍 Checking Docker volume '${NFS_VOLUME_NAME}'..."
+
+if ! docker volume inspect "${NFS_VOLUME_NAME}" >/dev/null 2>&1; then
+    echo "📦 Creating Docker volume '${NFS_VOLUME_NAME}'..."
+    docker volume create "${NFS_VOLUME_NAME}"
+else
+    echo "✅ Volume already exists."
+fi
+
+# -----------------------------------------------------------------------------
+# Create or start NFS container
+# -----------------------------------------------------------------------------
+
+echo "🔍 Checking NFS server container '${NFS_CONTAINER_NAME}'..."
+
+if ! docker ps -a --format '{{.Names}}' | grep -q "^${NFS_CONTAINER_NAME}$"; then
+
+    echo "🚀 Creating NFS server container..."
+
+    docker run -d \
+        --name "${NFS_CONTAINER_NAME}" \
+        --privileged \
+        -e SHARED_DIRECTORY=/exports \
+        -e ANONUID="${NFS_UID}" \
+        -e ANONGID="${NFS_GID}" \
+        -v "${NFS_VOLUME_NAME}:/exports" \
+        -p 111:111/tcp \
+        -p 111:111/udp \
+        -p 2049:2049/tcp \
+        -p 2049:2049/udp \
+        --network "${NFS_NETWORK_NAME}" \
+        --restart unless-stopped \
+        itsthenetwork/nfs-server-alpine
+
+else
+    echo "▶ NFS server container already exists."
+
+    if ! docker ps --format '{{.Names}}' | grep -q "^${NFS_CONTAINER_NAME}$"; then
+        echo "🚀 Starting existing NFS server container..."
+        docker start "${NFS_CONTAINER_NAME}" >/dev/null
+    else
+        echo "✅ NFS server container already running."
+    fi
+fi
+
+# -----------------------------------------------------------------------------
+# Prepare exported directory
+# -----------------------------------------------------------------------------
+
+EXPORT_PATH="/exports${NFS_MOUNTPOINT}"
+
+echo "📁 Preparing exported directory '${EXPORT_PATH}'..."
+
+docker exec "${NFS_CONTAINER_NAME}" sh -c "
+    mkdir -p '${EXPORT_PATH}/.mocked_nfs' && \
+    chown -R ${NFS_UID}:${NFS_GID} /exports && \
+    chmod -R 755 /exports
+"
+
+# -----------------------------------------------------------------------------
+# Print usage information
+# -----------------------------------------------------------------------------
+
+CONTAINER_IP="$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${NFS_CONTAINER_NAME}")"
+
+echo
+echo "✅ OpenFactory mocked NFS server is ready."
+echo
+echo "NFS server name          : ${NFS_CONTAINER_NAME} (\$NFS_CONTAINER_NAME)"
+echo "NFS export path          : ${NFS_MOUNTPOINT} (\$NFS_MOUNTPOINT)"
+echo "NFS server IP            : ${CONTAINER_IP} (\$CONTAINER_IP)"
+echo "NFS mountpoint owner UID : ${NFS_UID} (\$NFS_UID)"
+echo "NFS mountpoint owner GID : ${NFS_GID} (\$NFS_GID)"
+echo
+echo "⚠️  Applications accessing this NFS export should typically run with:"
+echo
+echo "    UID=${NFS_UID}"
+echo "    GID=${NFS_GID}"
+echo
+echo "Mount with:"
+echo
+echo "  sudo mount -t nfs ${CONTAINER_IP}:${NFS_MOUNTPOINT} /your/local/mountpoint"
+echo

--- a/.devcontainer/features/nfs-server/assets/stop-nfs.sh
+++ b/.devcontainer/features/nfs-server/assets/stop-nfs.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# OpenFactory Mocked NFS Server
+#
+# Stops the mocked NFS server container used by the OpenFactory SDK
+# and removes its persistent Docker volume.
+#
+# -----------------------------------------------------------------------------
+
+NFS_CONTAINER_NAME="devcontainer-nfs"
+NFS_VOLUME_NAME="devcontainer-nfsdata"
+
+echo "🛑 Stopping OpenFactory mocked NFS server..."
+
+# -----------------------------------------------------------------------------
+# Validate environment
+# -----------------------------------------------------------------------------
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "❌ Docker is required but was not found."
+    exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Stop container if it exists
+# -----------------------------------------------------------------------------
+
+if docker ps -a --format '{{.Names}}' | grep -q "^${NFS_CONTAINER_NAME}$"; then
+
+    if docker ps --format '{{.Names}}' | grep -q "^${NFS_CONTAINER_NAME}$"; then
+        echo "🛑 Stopping NFS server container '${NFS_CONTAINER_NAME}'..."
+        docker stop "${NFS_CONTAINER_NAME}" >/dev/null
+    else
+        echo "ℹ️  NFS server container '${NFS_CONTAINER_NAME}' is already stopped."
+    fi
+
+    echo "🗑️  Removing NFS server container '${NFS_CONTAINER_NAME}'..."
+    docker rm "${NFS_CONTAINER_NAME}" >/dev/null
+
+else
+    echo "ℹ️  NFS server container '${NFS_CONTAINER_NAME}' does not exist."
+fi
+
+# -----------------------------------------------------------------------------
+# Remove persistent volume
+# -----------------------------------------------------------------------------
+
+if docker volume inspect "${NFS_VOLUME_NAME}" >/dev/null 2>&1; then
+    echo "🗑️  Removing Docker volume '${NFS_VOLUME_NAME}'..."
+    docker volume rm "${NFS_VOLUME_NAME}" >/dev/null
+
+    echo "✅ Docker volume removed."
+else
+    echo "ℹ️  Docker volume '${NFS_VOLUME_NAME}' does not exist."
+fi
+
+# -----------------------------------------------------------------------------
+# Done
+# -----------------------------------------------------------------------------
+
+echo "✅ OpenFactory mocked NFS server cleanup complete."

--- a/.devcontainer/features/nfs-server/devcontainer-feature.json
+++ b/.devcontainer/features/nfs-server/devcontainer-feature.json
@@ -1,0 +1,26 @@
+{
+  "id": "nfs-server",
+  "version": "0.5.4",
+  "name": "OpenFactory NFS Server",
+  "description": "Provides a mocked NFS server suitable for the OpenFactory SDK.",
+  "options": {
+    "nfs-mountpoint": {
+      "type": "string",
+      "default": "/ofa/nfsvolume",
+      "description": "NFS mountpoint"
+    },
+    "nfs-uid": {
+      "type": "string",
+      "default": "1200",
+      "description": "UID of the owner of the exported NFS mountpoint"
+    },
+    "nfs-gid": {
+      "type": "string",
+      "default": "1200",
+      "description": "GID of the owner of the exported NFS mountpoint"
+    }
+  },
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/common-utils"
+  ]
+}

--- a/.devcontainer/features/nfs-server/install.sh
+++ b/.devcontainer/features/nfs-server/install.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -e
+
+EXPECTED_VERSION=$(grep '"version"' devcontainer-feature.json | sed -E 's/.*"([^"]+)".*/\1/')
+
+echo "🔧 Installing OpenFactory NFS Server feature v${EXPECTED_VERSION} ..."
+
+# -----------------------------------------------------------------------------
+# Check compatibility of OpenFactory feature versions
+# -----------------------------------------------------------------------------
+
+if [ -f /usr/local/etc/openfactory_version ]; then
+    INSTALLED_VERSION=$(cat /usr/local/etc/openfactory_version)
+
+    if [ "$INSTALLED_VERSION" != "$EXPECTED_VERSION" ]; then
+        echo "❌ OpenFactory features version mismatch"
+        echo "Installed: $INSTALLED_VERSION"
+        echo "Current:   $EXPECTED_VERSION"
+        exit 1
+    fi
+fi
+
+echo "$EXPECTED_VERSION" > /usr/local/etc/openfactory_version
+
+# -----------------------------------------------------------------------------
+# Copy feature assets
+# -----------------------------------------------------------------------------
+
+echo "📁 Copying OpenFactory NFS Server files..."
+
+mkdir -p "/usr/local/share/openfactory-nfs"
+cp -r "$(dirname "$0")/assets/." "/usr/local/share/openfactory-nfs"
+chmod +x /usr/local/share/openfactory-nfs/start-nfs.sh
+chmod +x /usr/local/share/openfactory-nfs/stop-nfs.sh
+
+# -----------------------------------------------------------------------------
+# Install helper commands
+# -----------------------------------------------------------------------------
+
+echo "🛠️ Installing helper commands..."
+
+ln -sf \
+    /usr/local/share/openfactory-nfs/start-nfs.sh \
+    /usr/local/bin/openfactory-start-nfs
+ln -sf \
+    /usr/local/share/openfactory-nfs/stop-nfs.sh \
+    /usr/local/bin/openfactory-stop-nfs
+
+# -----------------------------------------------------------------------------
+# Export environment variables
+# -----------------------------------------------------------------------------
+
+echo "🛠️ Setting environment variables..."
+
+cat << EOF > /etc/profile.d/00-openfactory-nfs.sh
+export NFS_UID="${NFS_UID}"
+export NFS_GID="${NFS_GID}"
+export NFS_MOUNTPOINT="${NFS_MOUNTPOINT}"
+
+export NFS_CONTAINER_NAME="devcontainer-nfs"
+export NFS_VOLUME_NAME="devcontainer-nfsdata"
+export NFS_NETWORK_NAME="factory-net"
+EOF
+
+chmod +x /etc/profile.d/00-openfactory-nfs.sh
+
+# -----------------------------------------------------------------------------
+# Add helpful aliases
+# -----------------------------------------------------------------------------
+
+echo "🛠️ Adding helpful aliases to /etc/bash.bashrc..."
+
+{
+  echo '# OpenFactory NFS feature aliases'
+  echo 'alias nfs-start="openfactory-start-nfs"'
+  echo 'alias nfs-stop="openfactory-stop-nfs"'
+} >> /etc/bash.bashrc
+
+# -----------------------------------------------------------------------------
+# Done
+# -----------------------------------------------------------------------------
+
+echo "✅ OpenFactory NFS Server feature setup complete."
+echo
+echo "Run:"
+echo
+echo "  openfactory-start-nfs"
+echo
+echo "to start the mocked NFS server."

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently, the SDK provides the following Dev Container features:
 | ----------------- | ----------------------------------------------------------------- |
 | `infra`           | Simulates the OpenFactory infrastructure (Kafka Cluster + ksqlDB) |
 | `opcua-connector` | Deploys an OpenFactory OPC UA Connector for application testing   |
+| `nfs-server`      | Provides a mocked NFS server for shared filesystem testing        |
 
 Each feature can be configured independently and further combined, depending on your development needs.
 
@@ -28,6 +29,7 @@ Once installed, the features allow you to start and stop infrastructure and OPC 
 | ----------------- | -------------------- | ---------------------- |
 | OpenFactory Infra | `spinup`             | `teardown`             |
 | OPC UA Connector  | `opcua-connector-up` | `opcua-connector-down` |
+| Mocked NFS Server | `nfs-start`          | `nfs-stop`             |
 
 
 ## 🚀 Usage
@@ -47,13 +49,14 @@ Example `.devcontainer/devcontainer.json`:
 {
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-    "ghcr.io/openfactoryio/openfactory-sdk/infra:0.4.8": {},
-    "ghcr.io/openfactoryio/openfactory-sdk/opcua-connector:0.4.8": {}
+    "ghcr.io/openfactoryio/openfactory-sdk/infra:0.5.5": {},
+    "ghcr.io/openfactoryio/openfactory-sdk/opcua-connector:0.5.5": {},
+    "ghcr.io/openfactoryio/openfactory-sdk/nfs-server:0.5.5": {}
   }
 }
 ```
 
-> 💡 **Note:** The **feature version** must match the OpenFactory version running in your factory (e.g. 0.4.8). Pinning ensures the SDK features remain compatible with the OpenFactory deployment you are targeting.
+> 💡 **Note:** The **feature version** must match the OpenFactory version running in your factory (e.g. 0.5.5). Pinning ensures the SDK features remain compatible with the OpenFactory deployment you are targeting.
 
 ### 2️⃣ OpenFactory Core Developers
 
@@ -89,6 +92,9 @@ Each feature provides optional configuration:
 |                   | `useLocalSdk`             | Use the local SDK source code instead of installing from GitHub | boolean | `false`                     |
 | `opcua-connector` | `opcua-connector-version` | Git ref of the OPC UA Connector image to install                | string  | *(matches feature version)* |
 |                   | `useLocalSdk`             | Use the local SDK source code instead of installing from GitHub | boolean | `false`                     |
+| `nfs-server`      | `nfs-mountpoint`          | Path exported by the mocked NFS server                          | string  | `/ofa/nfsvolume`            |
+|                   | `nfs-uid`                 | UID owning the exported NFS mountpoint                          | string  | `1200`                      |
+|                   | `nfs-gid`                 | GID owning the exported NFS mountpoint                          | string  | `1200`                      |
 
 ---
 
@@ -127,6 +133,29 @@ Each feature provides optional configuration:
   ```bash
   opcua-connector-up    – launch OPC UA Connector
   opcua-connector-down  – stop OPC UA Connector
+  ```
+
+**Mocked NFS Server (`nfs-server`) Feature:**
+
+* Install helper scripts to manage a mocked NFS server
+* Create a mocked NFS server container using Docker
+* Create a persistent Docker volume for NFS data
+* Define environment variables:
+
+  ```bash
+  NFS_CONTAINER_NAME=devcontainer-nfs
+  NFS_VOLUME_NAME=devcontainer-nfsdata
+  NFS_NETWORK_NAME=factory-net
+
+  NFS_MOUNTPOINT=<value of feature option id nfs-mountpoint>
+  NFS_UID=<value of feature option id nfs-uid>
+  NFS_GID=<value of feature option id nfs-gid>
+  ```
+* Add aliases:
+
+  ```bash
+  nfs-start  – start mocked NFS server
+  nfs-stop   – stop mocked NFS server
   ```
 
 All environment variables and aliases are available in every Bash terminal inside the Dev Container.

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -240,6 +240,50 @@ def bump_opcua_feature_version(version: str) -> None:
     print(f"[opcua-coordinator] opcua-coordinator-version.default updated: {old_default_coordinator} → {data['options']['opcua-coordinator-version']['default']}")
 
 
+def bump_nfs_feature_version(version: str) -> None:
+    """
+    Update the version for the NFS Server feature.
+
+    If version is "dev", it transforms the current version to "<base>-dev.1".
+    Otherwise, sets the feature version based on the semantic version provided.
+
+    Args:
+        version (str): The new version string, e.g., "0.5.4" or "dev".
+
+    Raises:
+        SystemExit: If the JSON file is missing or required fields are not found.
+    """
+    json_path = (
+        Path(__file__).resolve().parent.parent /
+        ".devcontainer/features/nfs-server/devcontainer-feature.json"
+    )
+
+    if not json_path.exists():
+        print("ERROR: devcontainer-feature.json (nfs-server) not found.")
+        sys.exit(1)
+
+    with json_path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    if "version" not in data:
+        print("ERROR: Required fields missing in nfs-server devcontainer-feature.json.")
+        sys.exit(1)
+
+    old_version = data["version"]
+
+    if version == "dev":
+        base_version = old_version.split("-")[0]
+        data["version"] = f"{base_version}-dev.1"
+    else:
+        data["version"] = pep440_to_semver(version)
+
+    with json_path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+    print(f"[nfs-server] version updated: {old_version} → {data['version']}")
+
+
 if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage: bump_version.py <new_version>")
@@ -249,6 +293,7 @@ if __name__ == "__main__":
     final_version = bump_pyproject_version(new_version)
     bump_infra_feature_version(new_version)
     bump_opcua_feature_version(new_version)
+    bump_nfs_feature_version(new_version)
 
     # print final version for workflow to capture
     print(final_version)


### PR DESCRIPTION
# Add mocked NFS server Dev Container feature

## Summary

This PR introduces a new Dev Container feature:

```text
nfs-server
```

providing a mocked NFS server suitable for OpenFactory development and testing workflows.

The feature installs helper utilities to create and manage an NFS server container inside the development environment using Docker.

---

## Added

### New Dev Container feature

```text
.devcontainer/features/nfs-server
```

including:

* `start-nfs.sh`
* `stop-nfs.sh`
* feature `README.md`
* `install.sh`
* `devcontainer-feature.json`

---

## Feature capabilities

The feature now provides:

* mocked NFS server deployment using:

  ```text
  itsthenetwork/nfs-server-alpine
  ```

* persistent Docker volume for NFS storage

* helper aliases:

  ```bash
  nfs-start
  nfs-stop
  ```

* exported environment variables:

  ```bash
  NFS_CONTAINER_NAME
  NFS_VOLUME_NAME
  NFS_NETWORK_NAME
  NFS_MOUNTPOINT
  NFS_UID
  NFS_GID
  ```

---

## Design changes

Unlike the initial implementation, the feature no longer launches Docker containers during feature installation.

Instead:

* the feature installs runtime helper scripts
* users explicitly start the mocked NFS server afterward

This makes the feature compatible with:

* Docker-in-Docker
* Codespaces
* local feature development
* CI environments

---

## Documentation updates

Updated:

* main SDK `README.md`
* feature-specific `README.md`

with:

* usage examples
* optional settings
* NFS mounting examples
* development workflow notes

---

## CI/CD updates

Updated:

```text
scripts/bump_version.py
```

to also bump:

```text
.devcontainer/features/nfs-server/devcontainer-feature.json
```

during release workflows.
