### PR TITLE
Fix Docker-in-Docker DNS compatibility

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
     }
   },
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:3.1.0": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:4.0.0": {},
     "./features/infra": {
       "useLocalSdk": true,
       "openfactory-version": "main"

--- a/.devcontainer/features/infra/README.md
+++ b/.devcontainer/features/infra/README.md
@@ -164,7 +164,7 @@ Example:
 curl http://demo-fastapi-app.openfactory.local/docs
 ```
 
-This works because the feature configures internal DNS using `dnsmasq`.
+This works because the feature automatically configures internal DNS using `dnsmasq`. No additional DNS configuration is required.
 
 ### 2️⃣ From your Host Machine (browser access)
 

--- a/.devcontainer/features/infra/assets/openfactory-sdk-startup.sh
+++ b/.devcontainer/features/infra/assets/openfactory-sdk-startup.sh
@@ -14,7 +14,7 @@
 #       *.openfactory.local → CONTAINER_IP
 # - Preserves existing upstream DNS servers from /etc/resolv.conf
 # - Starts dnsmasq (idempotent, safe to run multiple times)
-# - Updates /etc/resolv.conf to use local DNS (127.0.0.1)
+# - Configures /etc/resolv.conf to use dnsmasq via CONTAINER_IP
 #
 # Why:
 # - Enables URLs like:
@@ -30,6 +30,7 @@
 # Notes:
 # - Designed for devcontainer environments (not production)
 # - Avoids hardcoding public DNS (uses system-provided upstream DNS)
+# - dnsmasq listens on both 127.0.0.1 and CONTAINER_IP for Docker-in-Docker compatibility
 # - Safe to re-run (idempotent configuration)
 #
 # ------------------------------------------------------------------------------
@@ -64,16 +65,25 @@ fi
 # Create config directory
 $SUDO mkdir -p "$DNSMASQ_CONF_DIR"
 
-# Capture upstream DNS ----
-UPSTREAM_DNS=$(grep -E '^nameserver' /etc/resolv.conf | awk '{print $2}' | grep -v '^127\.0\.0\.1$')
+# Capture upstream DNS servers (excluding dnsmasq)
+UPSTREAM_DNS=$(
+  grep -E '^nameserver' /etc/resolv.conf \
+    | awk '{print $2}' \
+    | grep -vE "^(127\.0\.0\.1|${CONTAINER_IP})$"
+)
+
+if [ -z "$UPSTREAM_DNS" ]; then
+  echo "❌ [openfactory-sdk-startup.sh] No upstream DNS servers found."
+  exit 1
+fi
 
 # Write dnsmasq config (idempotent)
 $SUDO tee "$DNSMASQ_CONF_FILE" > /dev/null <<EOF
 # OpenFactory DNS
 address=/openfactory.local/${CONTAINER_IP}
 
-# Listen locally
-listen-address=127.0.0.1
+# Listen locally and on the container IP
+listen-address=127.0.0.1,${CONTAINER_IP}
 bind-interfaces
 
 # Forward everything else to upstream DNS
@@ -103,13 +113,13 @@ else
 fi
 
 # Update resolv.conf safely
-if ! grep -q "127.0.0.1" /etc/resolv.conf; then
+if ! grep -Fxq "nameserver ${CONTAINER_IP}" /etc/resolv.conf; then
   echo "🛠️ Updating /etc/resolv.conf..."
 
   $SUDO cp /etc/resolv.conf /etc/resolv.conf.openfactory.bak || true
 
   $SUDO tee /etc/resolv.conf > /dev/null <<EOF
-nameserver 127.0.0.1
+nameserver ${CONTAINER_IP}
 EOF
 
   echo "✅ resolv.conf updated"


### PR DESCRIPTION
# Fix Docker-in-Docker DNS compatibility

## Summary

This PR fixes DNS resolution for Docker-in-Docker when using the OpenFactory Infrastructure feature.

Previously, the feature configured `dnsmasq` to listen only on `127.0.0.1` and updated `/etc/resolv.conf` accordingly. While this allowed applications running directly inside the devcontainer to resolve `*.openfactory.local`, Docker-in-Docker could not propagate a loopback DNS server into child containers. As a result, Docker fell back to its default public DNS servers, causing DNS failures on networks where those resolvers were unavailable.

## Changes

* Configure `dnsmasq` to listen on both:

  * `127.0.0.1`
  * `CONTAINER_IP`
* Configure `/etc/resolv.conf` to use `CONTAINER_IP` instead of `127.0.0.1`.
* Exclude the local `dnsmasq` listener when determining upstream DNS servers.
* Add validation to ensure upstream DNS servers are available before starting `dnsmasq`.
* Update comments to document the Docker-in-Docker compatibility rationale.

## Result

The feature now provides transparent DNS resolution for:

* Applications running directly inside the devcontainer.
* Containers launched via Docker-in-Docker (`docker run`, `docker build`, etc.).

while continuing to:

* automatically resolve `*.openfactory.local`,
* preserve the host's upstream DNS configuration,
* require no additional configuration from developers.

## Validation

The following scenarios were verified successfully:

* ✅ `curl http://<app>.openfactory.local` resolves correctly inside the devcontainer.
* ✅ `docker build` successfully installs packages (`apt-get`, `pip`, etc.).
* ✅ Child containers inherit a usable DNS configuration instead of falling back to public DNS servers.
* ✅ Applications remain accessible from the host via Traefik path-based routing (`http://localhost/<app>`).
