### PR TITLE
Add Grafana Dev Container Feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,16 +22,29 @@
       "opcua-coordinator-version": "latest",
       "opcua-gateway-version": "latest"
     },
-    "./features/nfs-server": {}
+    "./features/nfs-server": {},
+    "./features/grafana": {}
   },
   "containerEnv": {
     "ENVIRONMENT": "local",
     "OPENFACTORY_UNS_SCHEMA": "/workspaces/openfactory-sdk/.devcontainer/uns.yml"
   },
-  "forwardPorts": [80],
+  "forwardPorts": [80, 3000, 9090, 12345],
   "portsAttributes": {
     "80": {
       "label": "Traefik",
+      "onAutoForward": "openBrowser"
+    },
+    "3000": {
+      "label": "Grafana",
+      "onAutoForward": "openBrowser"
+    },
+    "9090": {
+      "label": "Prometheus",
+      "onAutoForward": "openBrowser"
+    },
+    "12345": {
+      "label": "Grafana Alloy",
       "onAutoForward": "openBrowser"
     }
   },

--- a/.devcontainer/features/grafana/README.md
+++ b/.devcontainer/features/grafana/README.md
@@ -1,0 +1,96 @@
+# OpenFactory Grafana Dev Container Feature
+
+Installs **Grafana and OpenFactory observability tools** inside your Dev Container.
+
+## 📊 Deploy Grafana
+
+Once installed, the feature allows you to deploy Grafana for monitoring OpenFactory.
+
+Start the Grafana services:
+
+```bash
+grafana-up
+```
+
+Stop the Grafana services:
+
+```bash
+grafana-down
+```
+
+## 📝 Deploy Logging
+
+The feature also provides centralized logging using Loki and Alloy.
+
+Start the logging services:
+
+```bash
+logging-up
+```
+
+Stop the logging services:
+
+```bash
+logging-down
+```
+
+A Grafana dashboard for exploring logs is predefined.
+
+## 🚀 Usage
+
+Add the Grafana feature to your `devcontainer.json`:
+
+```json
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:4.0.0": {},
+    "ghcr.io/openfactoryio/openfactory-sdk/infra:0.6.5": {},
+    "ghcr.io/openfactoryio/openfactory-sdk/grafana:0.6.5": {}
+  },
+  "forwardPorts": [3000, 9090, 12345]
+}
+```
+
+> 💡 **Tip:** Version pinning ensures compatibility with the OpenFactory Core version running in your factory.
+
+The following services are then available:
+
+* Grafana on port `3000`
+* Prometheus on port `9090`
+* Grafana Alloy on port `12345`
+
+---
+
+## ✅ What This Feature Does
+
+* Copies the OpenFactory Grafana configuration files to `/usr/local/share/openfactory-grafana`.
+
+* Preconfigures the following Grafana datasources:
+
+  * **Prometheus** at `http://prometheus:9090`
+  * **Loki** at `http://loki:3100`
+
+* Provides a predefined Grafana dashboard for logging.
+
+* Adds these shell aliases:
+
+  ```bash
+  grafana-up      # Launch Grafana and Prometheus
+  grafana-down    # Stop Grafana and Prometheus
+  logging-up      # Launch Loki and Alloy
+  logging-down    # Stop Loki and Alloy
+  ```
+
+## 🧪 For Feature Developers
+
+If you're contributing to this feature, you may want to install it from the local source.
+
+Example `.devcontainer/devcontainer.json`:
+
+```json
+{
+  "features": {
+    "./features/grafana": {}
+  }
+}
+```

--- a/.devcontainer/features/grafana/assets/grafana/docker-compose.yml
+++ b/.devcontainer/features/grafana/assets/grafana/docker-compose.yml
@@ -1,0 +1,101 @@
+# ------------------------------------------------------------------------------
+# 📊 Grafana Visualization Platform (OpenFactory Monitoring Dashboards)
+# ------------------------------------------------------------------------------
+# This Docker Compose service deploys Grafana, the primary visualization and
+# dashboard platform used by OpenFactory.
+#
+# Core Responsibilities:
+# - Visualize metrics collected by Prometheus
+# - Provide interactive dashboards for infrastructure and applications
+# - Explore metrics using PromQL through Grafana Explore
+# - Manage dashboards, users, folders, and alerting
+#
+# Data Sources:
+# - Prometheus serves as the primary metrics backend
+# - Additional data sources (e.g. Loki or Tempo) may be added in the future
+# - Data sources are provisioned automatically at startup
+#
+# Dashboard Provisioning:
+# - Dashboards are loaded from:
+#
+#     /etc/grafana/provisioning/dashboards
+#
+# - Provisioning configuration and dashboard definitions are mounted from
+#   the host file system
+# - Dashboards become available automatically when Grafana starts
+#
+# Persistence:
+# - Grafana stores its internal SQLite database in the persistent Docker
+#   volume (`grafana-data`)
+# - The database contains:
+#
+#   - Users
+#   - Organizations
+#   - Dashboard definitions
+#   - Alert rules
+#   - Preferences
+#
+# User Interface:
+#
+#     http://localhost:3000
+#
+# Default Credentials:
+#
+#     Username: admin
+#     Password: admin
+#
+# (These credentials should be changed for production deployments.)
+#
+# Networking:
+# - Uses the external Docker network (`factory-net`)
+# - Connects to Prometheus and other monitoring backends over the shared
+#   monitoring network
+#
+# Notes:
+# - Grafana does not store monitoring metrics
+# - Metrics remain in Prometheus
+# - Grafana provides visualization, exploration, dashboards, and alerting
+# - Configuration is provisioned automatically during container startup
+# - The official Grafana Docker image is pulled at runtime
+#
+# References:
+# - Grafana Documentation:
+#   https://grafana.com/docs/
+# - Grafana Provisioning:
+#   https://grafana.com/docs/grafana/latest/administration/provisioning/
+# ------------------------------------------------------------------------------
+
+services:
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+
+    ports:
+      - "3000:3000"
+
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+
+    volumes:
+      # Persist Grafana database (users, dashboards, etc.)
+      - grafana-data:/var/lib/grafana
+
+      # Provision datasources
+      - ./provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+
+      # Provision dashboards
+      - ./provisioning/dashboards:/etc/grafana/provisioning/dashboards
+
+    restart: unless-stopped
+
+    networks:
+      - factory-net
+
+volumes:
+  grafana-data:
+
+networks:
+  factory-net:
+    external: true

--- a/.devcontainer/features/grafana/assets/grafana/provisioning/dashboards/dashboard.yml
+++ b/.devcontainer/features/grafana/assets/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: OpenFactory
+    orgId: 1
+    folder: OpenFactory
+    type: file
+
+    disableDeletion: false
+    allowUiUpdates: true
+
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/.devcontainer/features/grafana/assets/grafana/provisioning/dashboards/logging.json
+++ b/.devcontainer/features/grafana/assets/grafana/provisioning/dashboards/logging.json
@@ -1,0 +1,831 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "adrfxz2",
+    "generation": 33,
+    "creationTimestamp": "2026-07-20T21:25:36Z",
+    "labels": {},
+    "annotations": {}
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "grafana",
+            "version": "v0",
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "builtIn": true
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "Errors",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {container=~\".+\"}\r\n    | detected_level=\"error\"\r\n    [$__range]\r\n  )\r\n)",
+                        "queryType": "instant"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 1,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "Exceptions",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {container=~\".+\"}\r\n    | json\r\n    | level=\"ERROR\"\r\n    | exception!=\"\"\r\n    [$__range]\r\n  )\r\n)",
+                        "queryType": "instant"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 1,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "Warnings",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {container=~\".+\"}\r\n    | detected_level=\"warning\"\r\n    [$__range]\r\n  )\r\n)",
+                        "queryType": "instant"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 1,
+                        "color": "orange"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "id": 4,
+          "title": "Total logs",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {container=~\".+\"}\r\n    [$__range]\r\n  )\r\n)",
+                        "queryType": "instant"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "stat",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0"
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "id": 5,
+          "title": "Total Errors and Exceptions",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {container=~\".+\"}\r\n    | detected_level=\"error\"\r\n    [$__auto]\r\n  )\r\n)\r\nor\r\n(\r\n  sum(\r\n    count_over_time(\r\n      {container=~\".+\"}\r\n      [$__auto]\r\n    )\r\n  ) * 0\r\n)",
+                        "legendFormat": "Errors",
+                        "queryType": "range"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "builder",
+                        "expr": "sum(\r\n  count_over_time(\r\n    {container=~\".+\"}\r\n    | json\r\n    | level=\"ERROR\"\r\n    | exception!=\"\"\r\n    [$__auto]\r\n  )\r\n)",
+                        "legendFormat": "Exceptions",
+                        "queryType": "range"
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "annotations": {
+                  "clustering": -1,
+                  "multiLane": false
+                },
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "enableFacetedFilter": false,
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "noValue": "0",
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-7": {
+        "kind": "Panel",
+        "spec": {
+          "id": 7,
+          "title": "Errors by Container",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "code",
+                        "expr": "sum by (container) (\r\n  count_over_time(\r\n    {container=~\".+\"}\r\n    | detected_level=\"error\"\r\n    [$__range]\r\n  )\r\n)\r\nor\r\n(\r\n  sum by (container) (\r\n    count_over_time(\r\n      {container=~\".+\"}\r\n      [$__range]\r\n    )\r\n  ) * 0\r\n)",
+                        "legendFormat": "{{container}}",
+                        "queryType": "range",
+                        "step": ""
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "bargauge",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "displayMode": "basic",
+                "legend": {
+                  "calcs": [
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": false,
+                  "sortBy": "Max",
+                  "sortDesc": true
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 8,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "displayName": "${__field.displayName}",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 1,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0",
+                  "fieldMinMax": false
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      },
+      "panel-8": {
+        "kind": "Panel",
+        "spec": {
+          "id": 8,
+          "title": "Last Errors",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki",
+                      "version": "v0",
+                      "labels": {
+                        "grafana.app/export-datasource-name": "loki",
+                        "grafana.app/export-label": "loki-1"
+                      },
+                      "spec": {
+                        "direction": "backward",
+                        "editorMode": "builder",
+                        "expr": "{container=~\".+\"} | detected_level = `error`",
+                        "queryType": "range"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "logs",
+            "version": "13.1.0",
+            "spec": {
+              "options": {
+                "dedupStrategy": "none",
+                "enableInfiniteScrolling": false,
+                "enableLogDetails": true,
+                "prettifyLogMessage": true,
+                "showControls": true,
+                "showFieldSelector": true,
+                "showLevel": true,
+                "showTime": false,
+                "sortOrder": "Descending",
+                "syntaxHighlighting": true,
+                "timestampResolution": "ms",
+                "unwrappedColumns": true,
+                "wrapLogMessage": false
+              },
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "OpenFactory Logs Overview",
+              "collapse": false,
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "maxColumnCount": 4,
+                  "columnWidthMode": "narrow",
+                  "rowHeightMode": "short",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-4"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-3"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-1"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-2"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Errors and Exceptions",
+              "collapse": false,
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "maxColumnCount": 2,
+                  "columnWidthMode": "narrow",
+                  "rowHeightMode": "short",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-5"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Errors per Containers",
+              "collapse": false,
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "maxColumnCount": 3,
+                  "columnWidthMode": "standard",
+                  "rowHeightMode": "standard",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-7"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "title": "Last Errors",
+              "collapse": false,
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "maxColumnCount": 1,
+                  "columnWidthMode": "standard",
+                  "rowHeightMode": "standard",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-8"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-6h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Logging",
+    "variables": [],
+    "preferences": {
+      "layout": {
+        "kind": "GridLayout",
+        "spec": {
+          "items": []
+        }
+      }
+    }
+  }
+}

--- a/.devcontainer/features/grafana/assets/grafana/provisioning/datasources/loki.yml
+++ b/.devcontainer/features/grafana/assets/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false

--- a/.devcontainer/features/grafana/assets/grafana/provisioning/datasources/prometheus.yml
+++ b/.devcontainer/features/grafana/assets/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/.devcontainer/features/grafana/assets/logging/README.md
+++ b/.devcontainer/features/grafana/assets/logging/README.md
@@ -1,0 +1,47 @@
+# Grafana Loki Configuration
+
+The OpenFactory logging stack uses Grafana Loki to store and query container logs.
+
+Grafana must be configured with Loki as a data source before collected logs can be explored and visualized.
+
+## Add Loki as a Grafana Data Source
+
+In Grafana:
+
+1. Open **Connections → Data sources**.
+2. Select **Add new data source**.
+3. Select **Loki**.
+4. Configure the Loki server URL as:
+
+```
+http://loki:3100
+```
+
+5. Leave authentication disabled.
+6. Select **Save & test**.
+
+Grafana and Loki are connected to the shared `factory-net` Docker network, allowing Grafana to access Loki directly using the Docker service name `loki`.
+
+Loki does not need to expose port `3100` on the Docker hosts.
+
+## Explore Logs
+
+Open **Explore** in Grafana and select the Loki data source.
+
+Logs can be queried using the labels added by the Grafana Alloy collection pipeline.
+
+For example, to display logs from a specific container:
+
+```logql
+{container="opcua-gateway-1"}
+```
+
+Available labels include:
+
+* `container` — Docker container name
+* `service` — Docker Swarm service name
+* `node_id` — Docker Swarm node identifier
+
+Container logs may contain either plain text or structured JSON.
+
+OpenFactory Apps configured with the Loki logging backend emit structured JSON logs, allowing fields such as the log level, logger name, message, and application-defined logging context to be inspected and queried in Grafana.

--- a/.devcontainer/features/grafana/assets/logging/config.alloy
+++ b/.devcontainer/features/grafana/assets/logging/config.alloy
@@ -1,0 +1,124 @@
+// -----------------------------------------------------------------------------
+// OpenFactory Container Log Collection
+// -----------------------------------------------------------------------------
+// This configuration defines the Grafana Alloy pipeline used to collect logs
+// from Docker containers running on an OpenFactory host and forward them to
+// Grafana Loki.
+//
+// Log Flow:
+//
+//     Docker Containers
+//           |
+//           v
+//     discovery.docker
+//           |
+//           v
+//     discovery.relabel
+//           |
+//           v
+//     loki.source.docker
+//           |
+//           v
+//       loki.write
+//           |
+//           v
+//          Loki
+//
+// Each Alloy instance runs on one Docker Swarm node and accesses the local
+// Docker daemon through the mounted Docker socket.
+//
+// Container logs may contain either plain text or structured JSON. Alloy
+// forwards both formats to Loki without requiring applications to interact
+// directly with Alloy or Loki.
+// -----------------------------------------------------------------------------
+
+
+// -----------------------------------------------------------------------------
+// Docker Container Discovery
+// -----------------------------------------------------------------------------
+// Discovers containers running on the local Docker host.
+//
+// Docker exposes metadata for each discovered container through internal
+// `__meta_docker_*` labels. These labels are available during discovery but
+// are not automatically retained as Loki labels.
+//
+// The Docker socket is mounted into the Alloy container by the logging stack.
+// -----------------------------------------------------------------------------
+
+discovery.docker "containers" {
+  host = "unix:///var/run/docker.sock"
+}
+
+
+// -----------------------------------------------------------------------------
+// Docker Metadata Labels
+// -----------------------------------------------------------------------------
+// Converts selected Docker discovery metadata into persistent labels attached
+// to collected log streams.
+//
+// Labels:
+// - `container`: Docker container name
+// - `service`:   Docker Swarm service name
+// - `node_id`:   Docker Swarm node identifier
+//
+// Only stable infrastructure metadata is promoted to labels. Application-level
+// values such as asset UUIDs, measurements, counters, or other contextual log
+// fields remain part of the log entry to avoid creating high-cardinality Loki
+// labels.
+// -----------------------------------------------------------------------------
+
+discovery.relabel "docker_logs" {
+  targets = discovery.docker.containers.targets
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_swarm_service_name"]
+    target_label  = "service"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_swarm_node_id"]
+    target_label  = "node_id"
+  }
+}
+
+
+
+// -----------------------------------------------------------------------------
+// Docker Log Collection
+// -----------------------------------------------------------------------------
+// Reads stdout and stderr logs from the discovered Docker containers.
+//
+// The relabeled discovery targets provide both the containers to monitor and
+// the metadata labels attached to their log streams.
+//
+// Collected log entries are forwarded to the local `loki.write` component.
+// -----------------------------------------------------------------------------
+
+loki.source.docker "containers" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.relabel.docker_logs.output
+  forward_to = [loki.write.local.receiver]
+}
+
+
+// -----------------------------------------------------------------------------
+// Loki Output
+// -----------------------------------------------------------------------------
+// Forwards collected log entries to the centralized Loki service.
+//
+// Loki is reachable through the shared `factory-net` Docker network using its
+// Docker service name `loki`. The Loki HTTP port does not need to be published
+// on the Docker hosts.
+// -----------------------------------------------------------------------------
+
+loki.write "local" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}

--- a/.devcontainer/features/grafana/assets/logging/docker-compose.yml
+++ b/.devcontainer/features/grafana/assets/logging/docker-compose.yml
@@ -1,0 +1,151 @@
+
+# ------------------------------------------------------------------------------
+# 📝 Logging Infrastructure (OpenFactory Container Log Collection)
+# ------------------------------------------------------------------------------
+# This Docker Compose project deploys the logging infrastructure used to collect,
+# store, and query logs produced by containers running on the OpenFactory Cluster.
+#
+# Purpose:
+# - Discover Docker containers running on OpenFactory hosts
+# - Collect container logs from every Docker Swarm node
+# - Attach Docker and Docker Swarm metadata to collected logs
+# - Forward collected logs to a centralized log store
+# - Store logs for querying and visualization through Grafana
+#
+# Components:
+#
+# Grafana Alloy
+# -------------
+# Collects logs produced by Docker containers running on each OpenFactory host.
+#
+# Alloy discovers containers through the local Docker daemon and reads their
+# stdout and stderr log streams.
+#
+# The Alloy pipeline is configured in:
+#
+#     config.alloy
+#
+# The configuration defines:
+#
+# - Docker container discovery
+# - Docker and Docker Swarm metadata relabeling
+# - Docker log collection
+# - Forwarding of collected logs to Loki
+#
+# Alloy runs as a Docker Swarm Global service. Each Swarm node therefore runs
+# one Alloy instance, which collects logs from containers running on that node.
+#
+# Loki
+# ----
+# Provides centralized storage and querying of logs collected by Alloy.
+#
+# All Alloy instances forward collected logs to the Loki service over the
+# shared `factory-net` network.
+#
+# Loki stores its data in the persistent `loki-data` Docker volume.
+#
+# Grafana connects to Loki as a data source and provides log exploration,
+# filtering, querying, and visualization.
+#
+# Deployment Model:
+# - Alloy runs in Global mode
+# - Every Docker Swarm node automatically receives one Alloy instance
+# - Each Alloy instance collects logs from containers on its local Docker host
+# - Loki runs as a single centralized service
+# - All Alloy instances forward collected logs to Loki
+#
+# Log Flow:
+#
+#     Docker Containers
+#           |
+#           v
+#     Grafana Alloy
+#           |
+#           v
+#         Loki
+#           |
+#           v
+#        Grafana
+#
+# Networking:
+# - Uses the external Docker network (`factory-net`)
+# - Alloy sends collected logs to Loki over the shared network
+# - Grafana accesses Loki over the shared network
+# - Loki does not need to expose a host port
+#
+# Exposed Endpoints:
+#
+# Grafana Alloy:
+#     http://<host>:12345
+#
+# The Alloy HTTP endpoint provides its operational and debugging UI.
+#
+# Loki:
+#     http://loki:3100
+#
+# Loki is accessible internally through `factory-net`. Its port is not
+# published to the Docker hosts.
+#
+# Persistence:
+# - Loki stores log data in the `loki-data` Docker volume
+# - Alloy does not provide persistent log storage
+#
+# Notes:
+# - Alloy reads container logs through the local Docker socket
+# - The Docker socket is mounted read-only into the Alloy container
+# - Plain-text and structured JSON container logs can both be collected
+# - OpenFactory Apps require no direct connection to Alloy or Loki
+# - The OpenFactory logging backend is selected at deployment time
+# - Grafana uses Loki as a data source to query and visualize collected logs
+#
+# References:
+# - Grafana Alloy:
+#   https://grafana.com/docs/alloy/
+# - Grafana Loki:
+#   https://grafana.com/docs/loki/
+# ------------------------------------------------------------------------------
+
+services:
+
+  alloy:
+    image: grafana/alloy:latest
+    hostname: "{{.Node.Hostname}}"
+    command:
+      - "run"
+      - "--server.http.listen-addr=0.0.0.0:12345"
+      - "/etc/alloy/config.alloy"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./config.alloy:/etc/alloy/config.alloy:ro
+    networks:
+      - factory-net
+    ports:
+      - target: 12345
+        published: 12345
+        protocol: tcp
+        mode: host
+    deploy:
+      mode: global
+      restart_policy:
+        condition: any
+
+  loki:
+    image: grafana/loki:latest
+    command:
+      - "-config.file=/etc/loki/loki-config.yaml"
+    volumes:
+      - ./loki-config.yaml:/etc/loki/loki-config.yaml:ro
+      - loki-data:/loki
+    networks:
+      - factory-net
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+
+volumes:
+  loki-data:
+
+networks:
+  factory-net:
+    external: true

--- a/.devcontainer/features/grafana/assets/logging/loki-config.yaml
+++ b/.devcontainer/features/grafana/assets/logging/loki-config.yaml
@@ -1,0 +1,115 @@
+# ------------------------------------------------------------------------------
+# Grafana Loki Configuration
+# ------------------------------------------------------------------------------
+# This configuration defines the centralized log storage used by the
+# OpenFactory logging infrastructure.
+#
+# Grafana Alloy instances running on the Docker Swarm nodes collect container
+# logs and forward them to this Loki instance.
+#
+# Loki stores log data on the local filesystem backed by the persistent
+# `loki-data` Docker volume defined by the logging stack.
+#
+# Deployment Model:
+# - A single Loki instance is deployed
+# - Authentication is disabled because Loki is only accessible through the
+#   internal `factory-net` Docker network
+# - Log chunks and indexes are stored using local filesystem storage
+# - The Loki data directory is persisted using a Docker volume
+#
+# Log Flow:
+#
+#     Docker Containers
+#           |
+#           v
+#     Grafana Alloy
+#           |
+#           v
+#          Loki
+#           |
+#           v
+#        Grafana
+#
+# This configuration is intended for the current single-instance OpenFactory
+# logging deployment. A distributed or highly available Loki deployment would
+# require a different storage and replication configuration.
+# ------------------------------------------------------------------------------
+
+
+# ------------------------------------------------------------------------------
+# Authentication
+# ------------------------------------------------------------------------------
+# Disables Loki multi-tenant authentication.
+#
+# Loki is not exposed directly outside the OpenFactory Docker network. Access
+# is provided internally to services such as Grafana and Grafana Alloy through
+# the shared `factory-net` network.
+# ------------------------------------------------------------------------------
+auth_enabled: false
+
+
+# ------------------------------------------------------------------------------
+# HTTP Server
+# ------------------------------------------------------------------------------
+# Loki listens on its standard HTTP port 3100.
+#
+# Alloy uses this endpoint to push logs and Grafana uses it to query logs.
+# The port is available internally through the Docker service name:
+#
+#     http://loki:3100
+# ------------------------------------------------------------------------------
+server:
+  http_listen_port: 3100
+
+
+# ------------------------------------------------------------------------------
+# Common Configuration
+# ------------------------------------------------------------------------------
+# Defines storage and replication settings shared by Loki components.
+#
+# `path_prefix` defines the base directory used by Loki for local data.
+#
+# Log chunks and ruler data are stored below `/loki`, which is backed by the
+# persistent `loki-data` Docker volume.
+#
+# A replication factor of 1 is used because the current deployment contains
+# a single Loki instance.
+#
+# The ring uses an in-memory key-value store, which is sufficient for this
+# single-instance deployment.
+# ------------------------------------------------------------------------------
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+
+# ------------------------------------------------------------------------------
+# Storage Schema
+# ------------------------------------------------------------------------------
+# Defines how Loki stores and indexes log data.
+#
+# TSDB is used as the index store together with Loki schema version 13.
+# Log data is stored using the filesystem storage configured above.
+#
+# The `from` date defines when this schema configuration becomes applicable.
+# It must be a date in the past for a new deployment.
+#
+# Index data is organized using the `index_` prefix with a 24-hour index
+# period.
+# ------------------------------------------------------------------------------
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h

--- a/.devcontainer/features/grafana/devcontainer-feature.json
+++ b/.devcontainer/features/grafana/devcontainer-feature.json
@@ -1,0 +1,9 @@
+{
+  "id": "grafana",
+  "version": "0.6.5-rc.1",
+  "name": "OpenFactory Grafana",
+  "description": "Installs Grafana for OpenFactory",
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/common-utils"
+  ]
+}

--- a/.devcontainer/features/grafana/install.sh
+++ b/.devcontainer/features/grafana/install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+EXPECTED_VERSION=$(grep '"version"' devcontainer-feature.json | sed -E 's/.*"([^"]+)".*/\1/')
+echo "🔧 Installing OpenFactory Connectors feature feature v${EXPECTED_VERSION} ..."
+
+# Check compatibility of versions
+if [ -f /usr/local/etc/openfactory_version ]; then
+    INSTALLED_VERSION=$(cat /usr/local/etc/openfactory_version)
+
+    if [ "$INSTALLED_VERSION" != "$EXPECTED_VERSION" ]; then
+        echo "❌ OpenFactory features version mismatch"
+        echo "Installed: $INSTALLED_VERSION"
+        echo "Current:   $EXPECTED_VERSION"
+        exit 1
+    fi
+fi
+
+echo "$EXPECTED_VERSION" > /usr/local/etc/openfactory_version
+
+echo "📁 Copying Connectors files..."
+mkdir -p "/usr/local/share/openfactory-grafana"
+cp -r "$(dirname "$0")/assets/." "/usr/local/share/openfactory-grafana"
+
+# Set aliases
+echo "🛠️ Adding helpful aliases to /etc/bash.bashrc..."
+{
+  echo "alias grafana-up='docker compose -f /usr/local/share/openfactory-grafana/grafana/docker-compose.yml -p grafana up -d'"
+  echo "alias grafana-down='docker compose -f /usr/local/share/openfactory-grafana/grafana/docker-compose.yml -p grafana down'"
+  echo "alias logging-up='docker compose -f /usr/local/share/openfactory-grafana/logging/docker-compose.yml -p logging up -d'"
+  echo "alias logging-down='docker compose -f /usr/local/share/openfactory-grafana/logging/docker-compose.yml -p logging down'"
+} >> /etc/bash.bashrc
+
+echo "✅ OpenFactory Grafana feature setup complete."

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -298,6 +298,50 @@ def bump_nfs_feature_version(version: str) -> None:
     print(f"[nfs-server] version updated: {old_version} → {data['version']}")
 
 
+def bump_grafana_feature_version(version: str) -> None:
+    """
+    Update the version for the Grafana feature.
+
+    If version is "dev", it transforms the current version to "<base>-dev.1".
+    Otherwise, sets the feature version based on the semantic version provided.
+
+    Args:
+        version (str): The new version string, e.g., "0.5.4" or "dev".
+
+    Raises:
+        SystemExit: If the JSON file is missing or required fields are not found.
+    """
+    json_path = (
+        Path(__file__).resolve().parent.parent /
+        ".devcontainer/features/grafana/devcontainer-feature.json"
+    )
+
+    if not json_path.exists():
+        print("ERROR: devcontainer-feature.json (grafana) not found.")
+        sys.exit(1)
+
+    with json_path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    if "version" not in data:
+        print("ERROR: Required fields missing in grafana devcontainer-feature.json.")
+        sys.exit(1)
+
+    old_version = data["version"]
+
+    if version == "dev":
+        base_version = old_version.split("-")[0]
+        data["version"] = f"{base_version}-dev.1"
+    else:
+        data["version"] = pep440_to_semver(version)
+
+    with json_path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+    print(f"[nfs-server] version updated: {old_version} → {data['version']}")
+
+
 if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage: bump_version.py <new_version>")
@@ -308,6 +352,7 @@ if __name__ == "__main__":
     bump_infra_feature_version(new_version)
     bump_connectors_feature_version(new_version)
     bump_nfs_feature_version(new_version)
+    bump_grafana_feature_version(new_version)
 
     # print final version for workflow to capture
     print(final_version)


### PR DESCRIPTION
# Add Grafana Dev Container Feature

## Description

This PR introduces a new **Grafana Dev Container Feature** providing monitoring and centralized logging for local OpenFactory development.

The feature includes:

* **Grafana** for dashboards and visualization
* **Prometheus** for metrics
* **Loki** for centralized logging
* **Grafana Alloy** for log collection

Grafana is automatically provisioned with:

* Prometheus as a predefined datasource
* Loki as a predefined datasource
* A predefined dashboard for exploring OpenFactory logs

## Usage

The feature provides the following commands:

```bash
grafana-up
grafana-down

logging-up
logging-down
```

The Grafana/Prometheus and logging stacks can be started and stopped independently.

## Changes

* Added the new `grafana` Dev Container Feature
* Added Grafana and Prometheus deployment
* Added Loki and Alloy logging deployment
* Added predefined Prometheus and Loki datasources
* Added a predefined logging dashboard
* Added shell aliases for managing both stacks
* Added documentation for the new feature
